### PR TITLE
[PATCH] Silence a fatalized "used only once" warning

### DIFF
--- a/lib/Test/Expander.pm
+++ b/lib/Test/Expander.pm
@@ -80,7 +80,10 @@ our @EXPORT = (
   qw( BAIL_OUT bail_on_failure dies_ok is_deeply lives_ok new_ok require_ok restore_failure_handler throws_ok use_ok ),
 );
 
-*BAIL_OUT = \&bail_out;                                     # Explicit "sub BAIL_OUT" would be untestable
+{
+  no warnings 'once';
+  *BAIL_OUT = \&bail_out;                                     # Explicit "sub BAIL_OUT" would be untestable
+}
 
 sub bail_on_failure {
   _set_failure_handler(


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Test-Expander.
We thought you might be interested in it too.

    From 7df0abd5397aca2b809fe184200bf64018bc7f8f Mon Sep 17 00:00:00 2001
    From: Niko Tyni <ntyni@debian.org>
    Date: Sat, 24 Aug 2024 16:44:16 +0100
    Subject: [PATCH] Silence a fatalized "used only once" warning
    
    These warnings honour fatalizing with Perl 5.40, so the
    module started to fail with for example
    
      $ perl -Ilib lib/Test/Expander.pm
    
    as fatal warnings are requested inside.
    
    See https://github.com/Perl/perl5/issues/13814
    
    Bug-Debian: https://bugs.debian.org/1078117

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libtest-expander-perl/raw/master/debian/patches/0001-Silence-a-fatalized-used-only-once-warning.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
